### PR TITLE
feat: adiciona cadastro de sabores de pizza

### DIFF
--- a/src/app/cardapio/cadastro-pizza/components/PizzaCategorySectionProps.tsx
+++ b/src/app/cardapio/cadastro-pizza/components/PizzaCategorySectionProps.tsx
@@ -1,22 +1,42 @@
+"use client"
+
+import { useState } from 'react';
+import { CategoryModal } from './modals/CategoryModal';
+
 interface PizzaCategorySectionProps {
   onAddCategory: () => void;
 }
 
 export function PizzaCategorySection({ onAddCategory }: PizzaCategorySectionProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleCategoriesSelected = (categories: string[]) => {
+    console.log('Categorias selecionadas:', categories);
+    // Aqui você pode implementar a lógica para salvar as categorias selecionadas
+  };
+
   return (
-    <div className="bg-white p-6 rounded-2xl border border-zinc-200">
-      <div>
-        <h3 className="text-zinc-900 font-medium mb-2">Categorias</h3>
-        <p className="text-zinc-500 text-sm">As categorias ajudam seus clientes a encontrarem os produtos mais rápido.</p>
+    <>
+      <div className="bg-white p-6 rounded-2xl border border-zinc-200">
+        <div>
+          <h3 className="text-zinc-900 font-medium mb-2">Categorias</h3>
+          <p className="text-zinc-500 text-sm">As categorias ajudam seus clientes a encontrarem os produtos mais rápido.</p>
+        </div>
+
+        <button 
+          onClick={() => setIsModalOpen(true)}
+          className="mt-4 flex items-center gap-2 text-[#FF5900] bg-[#FFF6F3] px-4 py-2 rounded-lg text-sm"
+        >
+          <span>+</span>
+          <span>Adicionar categoria(s)</span>
+        </button>
       </div>
 
-      <button 
-        onClick={onAddCategory}
-        className="mt-4 flex items-center gap-2 text-[#FF5900] bg-[#FFF6F3] px-4 py-2 rounded-lg text-sm"
-      >
-        <span>+</span>
-        <span>Adicionar categoria(s)</span>
-      </button>
-    </div>
+      <CategoryModal 
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onConfirm={handleCategoriesSelected}
+      />
+    </>
   );
 }

--- a/src/app/cardapio/cadastro-pizza/components/modals/AddFlavorModal.tsx
+++ b/src/app/cardapio/cadastro-pizza/components/modals/AddFlavorModal.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 import { CaretLeft } from "@phosphor-icons/react";
+import { FlavorModalProps, Flavor } from '../../types';
+import { PIZZA_SIZES, AVAILABILITY_OPTIONS, ALLOWED_FILE_TYPES, MAX_FILE_SIZE, MIN_IMAGE_RESOLUTION } from '../../constants';
 
 interface FlavorSize {
   size: string;
@@ -10,21 +12,13 @@ interface FlavorSize {
   available: boolean;
 }
 
-interface Flavor {
-  id: string;
-  name: string;
-  description: string;
-  image: string;
-  sizes: FlavorSize[];
-}
-
 interface AddFlavorModalProps {
   isOpen: boolean;
   onClose: () => void;
   onAdd: (flavor: Flavor) => void;
 }
 
-export function AddFlavorModal({ isOpen, onClose, onAdd }: AddFlavorModalProps) {
+export function AddFlavorModal({ isOpen, onClose, onAdd }: FlavorModalProps) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [imageUrl, setImageUrl] = useState('/burger-icon.svg');
@@ -146,7 +140,7 @@ export function AddFlavorModal({ isOpen, onClose, onAdd }: AddFlavorModalProps) 
                 <label className="block text-zinc-400 text-sm mb-2">Tamanho</label>
                 <input
                   type="text"
-                  value="Pizza pequena"
+                  value={PIZZA_SIZES[0].label}
                   disabled
                   className="w-full px-4 py-3 rounded-lg border border-zinc-200 bg-zinc-50 text-zinc-900"
                 />
@@ -178,8 +172,11 @@ export function AddFlavorModal({ isOpen, onClose, onAdd }: AddFlavorModalProps) 
                   onChange={(e) => setSmallAvailable(e.target.value)}
                   className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-zinc-900 appearance-none bg-white"
                 >
-                  <option value="available">Disponível</option>
-                  <option value="unavailable">Indisponível</option>
+                  {AVAILABILITY_OPTIONS.map(option => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
                 </select>
               </div>
             </div>

--- a/src/app/cardapio/cadastro-pizza/components/modals/AddFlavorModal.tsx
+++ b/src/app/cardapio/cadastro-pizza/components/modals/AddFlavorModal.tsx
@@ -1,0 +1,240 @@
+"use client"
+
+import { useState } from 'react';
+import { CaretLeft } from "@phosphor-icons/react";
+
+interface FlavorSize {
+  size: string;
+  price: string;
+  promotionalPrice: string;
+  available: boolean;
+}
+
+interface Flavor {
+  id: string;
+  name: string;
+  description: string;
+  image: string;
+  sizes: FlavorSize[];
+}
+
+interface AddFlavorModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onAdd: (flavor: Flavor) => void;
+}
+
+export function AddFlavorModal({ isOpen, onClose, onAdd }: AddFlavorModalProps) {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [imageUrl, setImageUrl] = useState('/burger-icon.svg');
+  
+  // Estados para Pizza Pequena
+  const [smallPrice, setSmallPrice] = useState('');
+  const [smallPromotionalPrice, setSmallPromotionalPrice] = useState('');
+  const [smallAvailable, setSmallAvailable] = useState('available');
+
+  // Estados para Pizza Grande
+  const [largePrice, setLargePrice] = useState('');
+  const [largePromotionalPrice, setLargePromotionalPrice] = useState('');
+  const [largeAvailable, setLargeAvailable] = useState('available');
+
+  const handleAdd = () => {
+    const newFlavor = {
+      id: Math.random().toString(),
+      name,
+      description,
+      image: imageUrl,
+      sizes: [
+        {
+          size: 'Pizza pequena',
+          price: smallPrice,
+          promotionalPrice: smallPromotionalPrice,
+          available: smallAvailable === 'available'
+        },
+        {
+          size: 'Pizza grande',
+          price: largePrice,
+          promotionalPrice: largePromotionalPrice,
+          available: largeAvailable === 'available'
+        }
+      ]
+    };
+    
+    onAdd(newFlavor);
+    resetForm();
+    onClose();
+  };
+
+  const resetForm = () => {
+    setName('');
+    setDescription('');
+    setImageUrl('/burger-icon.svg');
+    setSmallPrice('');
+    setSmallPromotionalPrice('');
+    setSmallAvailable('available');
+    setLargePrice('');
+    setLargePromotionalPrice('');
+    setLargeAvailable('available');
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-30 backdrop-blur-sm flex justify-center items-start z-50 [margin-top:0!important]">
+      <div className="bg-white w-full max-w-[900px] rounded-2xl shadow-lg mt-4">
+        <div className="p-8">
+          {/* Header */}
+          <div className="flex items-center gap-3 mb-6">
+            <button onClick={onClose} className="hover:bg-zinc-100 rounded-lg">
+              <CaretLeft size={24} weight="bold" className="text-zinc-900" />
+            </button>
+            <h2 className="text-zinc-900 text-lg font-medium">Adicionar sabor</h2>
+          </div>
+
+          <div className="grid grid-cols-2 gap-8">
+            {/* Coluna da esquerda */}
+            <div className="space-y-6">
+              <div>
+                <label className="block text-zinc-900 mb-2">Nome do sabor</label>
+                <input
+                  type="text"
+                  placeholder="Mussarela"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-zinc-900 placeholder:text-zinc-400"
+                />
+              </div>
+
+              <div>
+                <label className="block text-zinc-900 mb-2">Descrição</label>
+                <textarea
+                  placeholder="Pizza de mussarela com molho de tomate e orégano."
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-zinc-900 placeholder:text-zinc-400 min-h-[140px] resize-none"
+                />
+              </div>
+            </div>
+
+            {/* Coluna da direita */}
+            <div>
+              <label className="block text-zinc-900 mb-2">Nome do sabor</label>
+              <div className="border-2 border-dashed border-zinc-200 rounded-lg p-6">
+                <div className="flex flex-col items-center justify-center gap-3">
+                  <div className="w-20 h-20 bg-zinc-100 rounded-lg flex items-center justify-center">
+                    <img src={imageUrl} alt="" className="w-12 h-12 opacity-30" />
+                  </div>
+                  <button className="text-[#FF5900] text-sm font-medium px-4 py-2 rounded-full border border-[#FF5900] flex items-center gap-2">
+                    <span className="text-lg">↑</span>
+                    Enviar foto
+                  </button>
+                  <div className="text-center space-y-1">
+                    <p className="text-zinc-500 text-sm">Formatos: jpg, jpeg, png ou heic</p>
+                    <p className="text-zinc-500 text-sm">Tamanhos: até 5 MB</p>
+                    <p className="text-zinc-500 text-sm">Resolução mínima recomendada: 500x500</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Preços */}
+          <div className="mt-6 space-y-4">
+            <div className="grid grid-cols-4 gap-4">
+              <div>
+                <label className="block text-zinc-400 text-sm mb-2">Tamanho</label>
+                <input
+                  type="text"
+                  value="Pizza pequena"
+                  disabled
+                  className="w-full px-4 py-3 rounded-lg border border-zinc-200 bg-zinc-50 text-zinc-900"
+                />
+              </div>
+              <div>
+                <label className="block text-zinc-400 text-sm mb-2">Valor</label>
+                <input
+                  type="text"
+                  placeholder="R$ 49,90"
+                  value={smallPrice}
+                  onChange={(e) => setSmallPrice(e.target.value)}
+                  className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-zinc-900 placeholder:text-zinc-400"
+                />
+              </div>
+              <div>
+                <label className="block text-zinc-400 text-sm mb-2">Valor promocional</label>
+                <input
+                  type="text"
+                  placeholder="R$ 39,90"
+                  value={smallPromotionalPrice}
+                  onChange={(e) => setSmallPromotionalPrice(e.target.value)}
+                  className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-zinc-900 placeholder:text-zinc-400"
+                />
+              </div>
+              <div>
+                <label className="block text-zinc-400 text-sm mb-2">Disponibilidade</label>
+                <select 
+                  value={smallAvailable}
+                  onChange={(e) => setSmallAvailable(e.target.value)}
+                  className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-zinc-900 appearance-none bg-white"
+                >
+                  <option value="available">Disponível</option>
+                  <option value="unavailable">Indisponível</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-4 gap-4">
+              <div>
+                <input
+                  type="text"
+                  value="Pizza grande"
+                  disabled
+                  className="w-full px-4 py-3 rounded-lg border border-zinc-200 bg-zinc-50 text-zinc-900"
+                />
+              </div>
+              <div>
+                <input
+                  type="text"
+                  placeholder="R$ 79,90"
+                  value={largePrice}
+                  onChange={(e) => setLargePrice(e.target.value)}
+                  className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-zinc-900 placeholder:text-zinc-400"
+                />
+              </div>
+              <div>
+                <input
+                  type="text"
+                  placeholder="R$ 59,90"
+                  value={largePromotionalPrice}
+                  onChange={(e) => setLargePromotionalPrice(e.target.value)}
+                  className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-zinc-900 placeholder:text-zinc-400"
+                />
+              </div>
+              <div>
+                <select 
+                  value={largeAvailable}
+                  onChange={(e) => setLargeAvailable(e.target.value)}
+                  className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-zinc-900 appearance-none bg-white"
+                >
+                  <option value="available">Disponível</option>
+                  <option value="unavailable">Indisponível</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="flex justify-end mt-8">
+            <button 
+              onClick={handleAdd}
+              className="bg-[#FF5900] text-white px-8 py-3 rounded-full text-sm font-medium hover:bg-[#FF5900]/90"
+            >
+              Adicionar
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/cardapio/cadastro-pizza/components/modals/CategoryModal.tsx
+++ b/src/app/cardapio/cadastro-pizza/components/modals/CategoryModal.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import { useState } from 'react';
+import { CaretLeft, MagnifyingGlass } from "@phosphor-icons/react";
+import { useCategories } from '@/hooks/useCategories';
+import { NewCategoryModal } from './NewCategoryModal';
+
+interface Category {
+  id: number;
+  name: string;
+  parentId?: number;
+}
+
+interface CategoryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (selectedCategories: string[]) => void;
+}
+
+export function CategoryModal({ isOpen, onClose, onConfirm }: CategoryModalProps) {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const [isNewCategoryModalOpen, setIsNewCategoryModalOpen] = useState(false);
+  const [localCategories, setLocalCategories] = useState<Category[]>([
+    { id: 1, name: 'Lanches' },
+    { id: 2, name: 'Bebidas' },
+    { id: 3, name: 'Refrigerantes', parentId: 2 },
+    { id: 4, name: 'Cervejas', parentId: 2 },
+    { id: 5, name: 'Combos' },
+    { id: 6, name: 'Promoções' },
+  ]);
+  
+  const filteredCategories = searchTerm
+    ? localCategories.filter(category => 
+        category.name.toLowerCase().includes(searchTerm.toLowerCase())
+      )
+    : localCategories;
+
+  const handleCategorySelect = (categoryName: string) => {
+    setSelectedCategories(prev => {
+      if (prev.includes(categoryName)) {
+        return prev.filter(cat => cat !== categoryName);
+      }
+      return [...prev, categoryName];
+    });
+  };
+
+  const handleNewCategory = (categoryName: string, parentCategory: string | null) => {
+    const newId = Math.max(...localCategories.map(c => c.id)) + 1;
+    const parentCategoryItem = parentCategory 
+      ? localCategories.find(c => c.name === parentCategory)
+      : null;
+
+    const newCategory: Category = {
+      id: newId,
+      name: categoryName,
+      ...(parentCategoryItem && { parentId: parentCategoryItem.id })
+    };
+
+    setLocalCategories(prev => [...prev, newCategory]);
+    setIsNewCategoryModalOpen(false);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center [margin-top:0!important] min-h-screen">
+      <div className="bg-white rounded-[32px] w-full max-w-[600px] max-h-[85vh] flex flex-col overflow-hidden my-auto">
+        {/* Header com título e botão voltar */}
+        <div className="flex items-center gap-3 p-8 pb-6">
+          <button onClick={onClose}>
+            <CaretLeft size={24} className="text-[#BABEC6]" />
+          </button>
+          <h2 className="text-2xl font-medium text-zinc-900">Adicionar categoria(s)</h2>
+        </div>
+
+        <div className="px-8 flex-1 overflow-y-auto">
+          {/* Campo de busca */}
+          <div className="relative mb-4">
+            <MagnifyingGlass className="absolute left-4 top-1/2 -translate-y-1/2 text-[#BABEC6]" size={20} />
+            <input
+              type="text"
+              placeholder="Buscar categoria"
+              className="w-full pl-12 pr-4 py-3 rounded-lg border border-zinc-200 outline-none text-sm placeholder:text-[#BABEC6]"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+            />
+          </div>
+
+          {/* Botão Criar nova categoria */}
+          <button 
+            onClick={() => setIsNewCategoryModalOpen(true)}
+            className="w-full text-left text-[#FF5900] hover:bg-[#FFF6F3] rounded-lg transition-colors"
+          >
+            <div className="px-4 py-3 flex items-center gap-2">
+              <span>+</span>
+              <span>Criar nova categoria</span>
+            </div>
+          </button>
+
+          {/* Lista de categorias */}
+          <div className="mt-6">
+            <p className="text-[#BABEC6] px-4 mb-4">Categorias cadastradas:</p>
+            
+            <div className="divide-y divide-zinc-100">
+              {filteredCategories.map((category) => (
+                <label 
+                  key={category.id}
+                  className="flex items-center w-full hover:bg-zinc-50 cursor-pointer group"
+                >
+                  <div className="flex items-center py-4 px-4 w-full">
+                    <input
+                      type="checkbox"
+                      checked={selectedCategories.includes(category.name)}
+                      onChange={() => handleCategorySelect(category.name)}
+                      className="mr-3 rounded border-[#BABEC6]"
+                    />
+                    {category.parentId ? (
+                      <div className="flex items-center">
+                        <span className="text-[#BABEC6] mr-2 ml-8">›</span>
+                        <span className="text-[#BABEC6]">{category.name}</span>
+                      </div>
+                    ) : (
+                      <span className="text-zinc-900">{category.name}</span>
+                    )}
+                  </div>
+                </label>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Footer com botão de continuar */}
+        <div className="border-t border-zinc-100 p-4 mt-auto">
+          <div className="flex justify-end">
+            <button
+              onClick={() => {
+                onConfirm(selectedCategories);
+                onClose();
+              }}
+              className="bg-[#FF5900] text-white px-8 py-3 rounded-full text-sm font-medium hover:bg-[#FF5900]/90"
+            >
+              Continuar
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <NewCategoryModal
+        isOpen={isNewCategoryModalOpen}
+        onClose={() => setIsNewCategoryModalOpen(false)}
+        onConfirm={handleNewCategory}
+        availableCategories={localCategories.filter(c => !c.parentId).map(c => c.name)}
+      />
+    </div>
+  );
+}

--- a/src/app/cardapio/cadastro-pizza/components/modals/NewCategoryModal.tsx
+++ b/src/app/cardapio/cadastro-pizza/components/modals/NewCategoryModal.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { useState } from 'react';
+import { CaretLeft } from "@phosphor-icons/react";
+
+interface NewCategoryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (categoryName: string, parentCategory: string | null) => void;
+  availableCategories: string[];
+}
+
+export function NewCategoryModal({ isOpen, onClose, onConfirm, availableCategories }: NewCategoryModalProps) {
+  const [categoryName, setCategoryName] = useState('');
+  const [parentCategory, setParentCategory] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = () => {
+    if (categoryName.trim()) {
+      onConfirm(categoryName.trim(), parentCategory);
+      setCategoryName('');
+      setParentCategory(null);
+      onClose();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center [margin-top:0!important] min-h-screen">
+      <div className="bg-white rounded-[32px] w-full max-w-[600px] flex flex-col overflow-hidden my-auto">
+        {/* Header */}
+        <div className="flex items-center gap-3 p-8 pb-6">
+          <button onClick={onClose}>
+            <CaretLeft size={24} className="text-[#BABEC6]" />
+          </button>
+          <h2 className="text-2xl font-medium text-zinc-900">Nova categoria</h2>
+        </div>
+
+        <div className="px-8 flex-1">
+          {/* Nome da categoria */}
+          <div className="mb-6">
+            <label className="block text-zinc-900 mb-2">Nome da categoria</label>
+            <input
+              type="text"
+              placeholder="Ex: Pizza grande ou Pizza média"
+              value={categoryName}
+              onChange={(e) => setCategoryName(e.target.value)}
+              className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-sm text-zinc-900 placeholder:text-[#BABEC6]"
+            />
+          </div>
+
+          {/* Subcategoria */}
+          <div className="mb-6">
+            <label className="block text-zinc-900 mb-2">É uma subcategoria de:</label>
+            <select
+              value={parentCategory || ''}
+              onChange={(e) => setParentCategory(e.target.value || null)}
+              className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-sm text-zinc-900"
+            >
+              <option value="">Selecione uma categoria ou não</option>
+              {availableCategories.map((category) => (
+                <option key={category} value={category}>
+                  {category}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-zinc-100 p-4 mt-6">
+          <div className="flex justify-end">
+            <button
+              onClick={handleSubmit}
+              className="bg-[#FF5900] text-white px-8 py-3 rounded-full text-sm font-medium hover:bg-[#FF5900]/90"
+            >
+              Continuar
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/cardapio/cadastro-pizza/components/sections/EdgeSection.tsx
+++ b/src/app/cardapio/cadastro-pizza/components/sections/EdgeSection.tsx
@@ -2,12 +2,7 @@
 
 import { useState } from 'react';
 import { Trash, PencilSimple } from "@phosphor-icons/react";
-
-interface Edge {
-  flavor: string;
-  price: string;
-  available: boolean;
-}
+import { Edge } from '../../types';
 
 export function EdgeSection() {
   const [isEditing, setIsEditing] = useState(true);

--- a/src/app/cardapio/cadastro-pizza/components/sections/EdgeSection.tsx
+++ b/src/app/cardapio/cadastro-pizza/components/sections/EdgeSection.tsx
@@ -1,0 +1,172 @@
+"use client"
+
+import { useState } from 'react';
+import { Trash, PencilSimple } from "@phosphor-icons/react";
+
+interface Edge {
+  flavor: string;
+  price: string;
+  available: boolean;
+}
+
+export function EdgeSection() {
+  const [isEditing, setIsEditing] = useState(true);
+  const [edges, setEdges] = useState<Edge[]>([]);
+  const [forms, setForms] = useState<any[]>([]);
+  const [showFields, setShowFields] = useState(false);
+
+  const handleAddEdge = () => {
+    setShowFields(true);
+    const newId = forms.length;
+    setForms(prev => [...prev, { id: newId, flavor: '', price: '', available: "true" }]);
+  };
+
+  const handleDeleteEdge = (id: number) => {
+    setForms(prev => prev.filter(form => form.id !== id));
+  };
+
+  const handleEdit = () => {
+    const newForms = edges.map((edge, index) => ({
+      id: index,
+      flavor: edge.flavor,
+      price: edge.price,
+      available: edge.available.toString()
+    }));
+    setForms(newForms);
+    setIsEditing(true);
+  };
+
+  const handleConfirm = () => {
+    const newEdges = forms.map(form => ({
+      flavor: form.flavor,
+      price: form.price,
+      available: form.available === "true"
+    }));
+    setEdges(newEdges);
+    setIsEditing(false);
+    setForms([]);
+  };
+
+  if (!isEditing && edges.length > 0) {
+    return (
+      <div className="bg-white p-6 rounded-2xl border border-zinc-200">
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <h3 className="text-zinc-900 font-medium mb-2">Bordas</h3>
+            <p className="text-zinc-500 text-sm">
+              Ofereça aos seus clientes opções de borda recheada.
+            </p>
+          </div>
+          <button
+            onClick={handleEdit}
+            className="flex items-center gap-2 text-[#FF5900] text-sm font-medium border border-[#FF5900] rounded-lg px-4 py-2"
+          >
+            <PencilSimple size={16} />
+            Alterar
+          </button>
+        </div>
+
+        <div className="mt-4">
+          <div className="grid grid-cols-[1fr_auto] gap-4">
+            <span className="text-zinc-500 text-sm">Sabor</span>
+            <span className="text-zinc-500 text-sm">Disp.</span>
+          </div>
+          {edges.map((edge, index) => (
+            <div key={index} className="grid grid-cols-[1fr_auto] gap-4 mt-4">
+              <span className="text-zinc-900">{edge.flavor}</span>
+              <div className="flex items-center">
+                <div className={`w-2 h-2 rounded-full ${edge.available ? 'bg-emerald-500' : 'bg-red-500'}`}></div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white p-6 rounded-2xl border border-zinc-200">
+      <div>
+        <h3 className="text-zinc-900 font-medium mb-2">Bordas</h3>
+        <p className="text-zinc-500 text-sm">
+          Ofereça aos seus clientes opções de borda recheada.
+        </p>
+      </div>
+
+      <button 
+        onClick={handleAddEdge}
+        className="mt-4 flex items-center gap-2 text-[#FF5900] hover:text-[#FF5900]/90"
+      >
+        <span className="text-lg">+</span>
+        <span className="text-sm">Adicionar borda</span>
+      </button>
+
+      {showFields && (
+        <>
+          <div className="mt-4 grid grid-cols-[2fr_2fr_2fr_auto] gap-4">
+            <span className="text-zinc-500 text-sm">Sabor</span>
+            <span className="text-zinc-500 text-sm">Valor</span>
+            <span className="text-zinc-500 text-sm">Disponibilidade</span>
+            <span></span>
+          </div>
+
+          {forms.map((form) => (
+            <div key={form.id} className="mt-4 grid grid-cols-[2fr_2fr_2fr_auto] gap-4 items-center">
+              <input
+                type="text"
+                placeholder="Requeijão"
+                value={form.flavor}
+                onChange={(e) => {
+                  setForms(prev => prev.map(f => 
+                    f.id === form.id ? { ...f, flavor: e.target.value } : f
+                  ));
+                }}
+                className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-sm text-zinc-900 placeholder:text-[#BABEC6]"
+              />
+              <input
+                type="text"
+                placeholder="R$ 0,00"
+                value={form.price}
+                onChange={(e) => {
+                  setForms(prev => prev.map(f => 
+                    f.id === form.id ? { ...f, price: e.target.value } : f
+                  ));
+                }}
+                className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-sm text-zinc-900 placeholder:text-[#BABEC6]"
+              />
+              <select
+                value={form.available}
+                onChange={(e) => {
+                  setForms(prev => prev.map(f => 
+                    f.id === form.id ? { ...f, available: e.target.value } : f
+                  ));
+                }}
+                className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-sm text-zinc-900"
+              >
+                <option value="true">Disponível</option>
+                <option value="false">Indisponível</option>
+              </select>
+              <button
+                onClick={() => handleDeleteEdge(form.id)}
+                className="h-[46px] w-[46px] flex items-center justify-center rounded-lg border border-red-200 hover:bg-red-50"
+              >
+                <Trash size={20} className="text-red-500" />
+              </button>
+            </div>
+          ))}
+
+          {forms.length > 0 && (
+            <div className="flex justify-end mt-6">
+              <button 
+                onClick={handleConfirm}
+                className="bg-[#FF5900] text-white px-8 py-3 rounded-full text-sm font-medium hover:bg-[#FF5900]/90"
+              >
+                Confirmar
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/cardapio/cadastro-pizza/components/sections/FlavorSection.tsx
+++ b/src/app/cardapio/cadastro-pizza/components/sections/FlavorSection.tsx
@@ -3,21 +3,7 @@
 import { useState } from 'react';
 import { PencilSimple, Trash, MagnifyingGlass } from "@phosphor-icons/react";
 import { AddFlavorModal } from '../modals/AddFlavorModal';
-
-interface FlavorSize {
-  size: string;
-  price: string;
-  promotionalPrice: string;
-  available: boolean;
-}
-
-interface Flavor {
-  id: string;
-  name: string;
-  description: string;
-  image: string;
-  sizes: FlavorSize[];
-}
+import { Flavor, FlavorSize } from '../../types';
 
 export function FlavorSection() {
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/src/app/cardapio/cadastro-pizza/components/sections/FlavorSection.tsx
+++ b/src/app/cardapio/cadastro-pizza/components/sections/FlavorSection.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import { useState } from 'react';
+import { PencilSimple, Trash, MagnifyingGlass } from "@phosphor-icons/react";
+import { AddFlavorModal } from '../modals/AddFlavorModal';
+
+interface FlavorSize {
+  size: string;
+  price: string;
+  promotionalPrice: string;
+  available: boolean;
+}
+
+interface Flavor {
+  id: string;
+  name: string;
+  description: string;
+  image: string;
+  sizes: FlavorSize[];
+}
+
+export function FlavorSection() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [flavors, setFlavors] = useState<Flavor[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const handleAddFlavor = (newFlavor: Flavor) => {
+    setFlavors(prev => [...prev, newFlavor]);
+  };
+
+  return (
+    <>
+      <div className="bg-white p-6 rounded-2xl border border-zinc-200">
+        <div>
+          <h3 className="text-zinc-900 font-medium mb-2">Sabores</h3>
+          <p className="text-zinc-500 text-sm">
+            Sabores de pizzas disponíveis.
+          </p>
+        </div>
+
+        <button 
+          onClick={() => setIsModalOpen(true)}
+          className="mt-4 flex items-center gap-2 text-[#FF5900] hover:text-[#FF5900]/90"
+        >
+          <span className="text-lg">+</span>
+          <span className="text-sm">Adicionar sabor</span>
+        </button>
+
+        {flavors.length > 0 && (
+          <>
+            <div className="mt-6 relative">
+              <MagnifyingGlass size={20} className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-400" />
+              <input
+                type="text"
+                placeholder="Buscar sabor"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-full pl-12 pr-4 py-3 rounded-lg border border-zinc-200 outline-none text-zinc-900 placeholder:text-zinc-400"
+              />
+            </div>
+
+            <div className="mt-6">
+              <div className="grid grid-cols-[auto_1fr_150px_1fr_1fr_100px_100px] items-center gap-4 pb-4 border-b border-zinc-100">
+                <div></div>
+                <span className="text-zinc-500 text-sm">Sabor</span>
+                <span className="text-zinc-500 text-sm">Tamanho</span>
+                <span className="text-zinc-500 text-sm">Preço</span>
+                <span className="text-zinc-500 text-sm">Preço promocional</span>
+                <span className="text-zinc-500 text-sm text-center">Disponibilidade</span>
+                <span className="text-zinc-500 text-sm text-center">Ações</span>
+              </div>
+
+              {flavors.map((flavor) => (
+                <div key={flavor.id}>
+                  {flavor.sizes.map((size, index) => (
+                    <div key={`${flavor.id}-${size.size}`} 
+                      className="grid grid-cols-[auto_1fr_150px_1fr_1fr_100px_100px] items-center gap-4 py-4 border-b border-zinc-100"
+                    >
+                      {index === 0 && (
+                        <>
+                          <img src={flavor.image} alt="" className="w-12 h-12 rounded object-cover row-span-2" />
+                          <div className="row-span-2">
+                            <p className="text-[#FF5900] font-medium">{flavor.name}</p>
+                            <p className="text-zinc-500 text-sm">{flavor.description}</p>
+                          </div>
+                        </>
+                      )}
+                      {index !== 0 && <div className="col-span-2" />}
+                      <span className="text-zinc-900 whitespace-nowrap">{size.size}</span>
+                      <span className="text-zinc-900">R$ {size.price}</span>
+                      <span className="text-zinc-900">R$ {size.promotionalPrice}</span>
+                      <div className="flex justify-center">
+                        <div className={`w-2 h-2 rounded-full ${size.available ? 'bg-emerald-500' : 'bg-red-500'}`} />
+                      </div>
+                      {index === 0 && (
+                        <div className="row-span-2 flex items-center justify-center gap-2">
+                          <button className="p-2 rounded-lg hover:bg-zinc-50 border border-zinc-200">
+                            <PencilSimple size={16} className="text-zinc-500" />
+                          </button>
+                          <button className="p-2 rounded-lg hover:bg-red-50 border border-red-200">
+                            <Trash size={16} className="text-red-500" />
+                          </button>
+                        </div>
+                      )}
+                      {index !== 0 && <div />}
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+
+      <AddFlavorModal 
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onAdd={handleAddFlavor}
+      />
+    </>
+  );
+}

--- a/src/app/cardapio/cadastro-pizza/components/sections/PizzaCategorySection.tsx
+++ b/src/app/cardapio/cadastro-pizza/components/sections/PizzaCategorySection.tsx
@@ -1,22 +1,68 @@
+"use client"
+
+import { useState } from 'react';
+import { PencilSimple } from "@phosphor-icons/react";
+import { CategoryModal } from '../modals/CategoryModal';
+
 interface PizzaCategorySectionProps {
   onAddCategory: () => void;
 }
 
 export function PizzaCategorySection({ onAddCategory }: PizzaCategorySectionProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+
+  const handleCategoriesSelected = (categories: string[]) => {
+    setSelectedCategories(categories);
+  };
+
   return (
-    <div className="bg-white p-6 rounded-2xl border border-zinc-200">
-      <div>
-        <h3 className="text-zinc-900 font-medium mb-2">Categorias</h3>
-        <p className="text-zinc-500 text-sm">As categorias ajudam seus clientes a encontrarem os produtos mais rápido.</p>
+    <>
+      <div className="bg-white p-6 rounded-2xl border border-zinc-200">
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-zinc-900 font-medium">Categorias</h3>
+          {selectedCategories.length > 0 && (
+            <button 
+              onClick={() => setIsModalOpen(true)}
+              className="flex items-center gap-2 text-[#FF5900] text-sm font-medium"
+            >
+              <PencilSimple className="w-4 h-4" />
+              Alterar
+            </button>
+          )}
+        </div>
+
+        <p className="text-zinc-500 text-sm mb-4">
+          As categorias ajudam seus clientes a encontrarem os produtos mais rápido.
+        </p>
+
+        {selectedCategories.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {selectedCategories.map((category) => (
+              <div 
+                key={category}
+                className="px-4 py-2 bg-emerald-50 text-emerald-700 rounded-full text-sm"
+              >
+                {category}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <button 
+            onClick={() => setIsModalOpen(true)}
+            className="flex items-center gap-2 text-[#FF5900] bg-[#FFF6F3] px-4 py-2 rounded-lg text-sm"
+          >
+            <span>+</span>
+            <span>Adicionar categoria(s)</span>
+          </button>
+        )}
       </div>
 
-      <button 
-        onClick={onAddCategory}
-        className="mt-4 flex items-center gap-2 text-[#FF5900] bg-[#FFF6F3] px-4 py-2 rounded-lg text-sm"
-      >
-        <span>+</span>
-        <span>Adicionar categoria(s)</span>
-      </button>
-    </div>
+      <CategoryModal 
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onConfirm={handleCategoriesSelected}
+      />
+    </>
   );
 }

--- a/src/app/cardapio/cadastro-pizza/components/sections/SizeSection.tsx
+++ b/src/app/cardapio/cadastro-pizza/components/sections/SizeSection.tsx
@@ -1,0 +1,193 @@
+"use client"
+
+import { useState } from 'react';
+import { Trash, PencilSimple } from "@phosphor-icons/react";
+
+interface Size {
+  name: string;
+  slices: string;
+  flavors: string;
+  available: boolean;
+}
+
+export function SizeSection() {
+  const [isEditing, setIsEditing] = useState(true);
+  const [sizes, setSizes] = useState<Size[]>([]);
+  const [forms, setForms] = useState<any[]>([]);
+  const [showFields, setShowFields] = useState(false);
+
+  const handleConfirm = () => {
+    const newSizes = forms.map(form => ({
+      name: form.name,
+      slices: form.slices,
+      flavors: form.flavors,
+      available: form.available === "true"
+    }));
+    setSizes(newSizes);
+    setIsEditing(false);
+    setForms([]);
+  };
+
+  const handleEdit = () => {
+    const newForms = sizes.map((size, index) => ({
+      id: index,
+      name: size.name,
+      slices: size.slices,
+      flavors: size.flavors,
+      available: size.available.toString()
+    }));
+    setForms(newForms);
+    setIsEditing(true);
+  };
+
+  if (!isEditing && sizes.length > 0) {
+    return (
+      <div className="bg-white p-6 rounded-2xl border border-zinc-200">
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <h3 className="text-zinc-900 font-medium mb-2">Tamanhos</h3>
+            <p className="text-zinc-500 text-sm">
+              Informe os tamanhos de pizzas, quantidade de fatias e quantidade de sabores de forma individual.
+            </p>
+          </div>
+          <button
+            onClick={handleEdit}
+            className="flex items-center gap-2 text-[#FF5900] text-sm font-medium border border-[#FF5900] rounded-lg px-4 py-2"
+          >
+            <PencilSimple size={16} />
+            Alterar
+          </button>
+        </div>
+
+        <div className="mt-4">
+          <div className="grid grid-cols-[1fr_auto] gap-4">
+            <span className="text-zinc-500 text-sm">Tamanho</span>
+            <span className="text-zinc-500 text-sm">Disp.</span>
+          </div>
+          {sizes.map((size, index) => (
+            <div key={index} className="grid grid-cols-[1fr_auto] gap-4 mt-4">
+              <span className="text-zinc-900">{size.name}</span>
+              <div className="flex items-center">
+                <div className={`w-2 h-2 rounded-full ${size.available ? 'bg-emerald-500' : 'bg-red-500'}`}></div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const handleAddSize = () => {
+    setShowFields(true);
+    const newId = forms.length;
+    setForms(prev => [...prev, { id: newId, name: '', slices: '', flavors: '', available: "true" }]);
+  };
+
+  const handleDeleteSize = (id: number) => {
+    setForms(prev => prev.filter(form => form.id !== id));
+  };
+
+  return (
+    <div className="bg-white p-6 rounded-2xl border border-zinc-200">
+      <div>
+        <h3 className="text-zinc-900 font-medium mb-2">Tamanhos</h3>
+        <p className="text-zinc-500 text-sm">
+          Informe os tamanhos de pizzas, quantidade de fatias e quantidade de sabores de forma individual.
+        </p>
+      </div>
+
+      <button 
+        onClick={handleAddSize}
+        className="mt-4 flex items-center gap-2 text-[#FF5900] hover:text-[#FF5900]/90"
+      >
+        <span className="text-lg">+</span>
+        <span className="text-sm">Adicionar tamanho</span>
+      </button>
+
+      {showFields && (
+        <div className="mt-4 grid grid-cols-[2fr_2fr_2fr_2fr_auto] gap-4">
+          <span className="text-zinc-500 text-sm">Nome</span>
+          <span className="text-zinc-500 text-sm">Fatias</span>
+          <span className="text-zinc-500 text-sm">Sabores</span>
+          <span className="text-zinc-500 text-sm">Disponibilidade</span>
+          <span></span>
+        </div>
+      )}
+
+      {forms.map((form) => (
+        <div key={form.id} className="mt-4 grid grid-cols-[2fr_2fr_2fr_2fr_auto] gap-4 items-center">
+          <input
+            type="text"
+            placeholder="Grande"
+            value={form.name}
+            onChange={(e) => {
+              setForms(prev => prev.map(f => 
+                f.id === form.id ? { ...f, name: e.target.value } : f
+              ));
+            }}
+            className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-sm text-zinc-900 placeholder:text-[#BABEC6]"
+          />
+          <select
+            value={form.slices}
+            onChange={(e) => {
+              setForms(prev => prev.map(f => 
+                f.id === form.id ? { ...f, slices: e.target.value } : f
+              ));
+            }}
+            className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-sm text-zinc-900"
+          >
+            <option value="">8 fatias</option>
+            <option value="6">6 fatias</option>
+            <option value="8">8 fatias</option>
+            <option value="10">10 fatias</option>
+            <option value="12">12 fatias</option>
+          </select>
+          <select
+            value={form.flavors}
+            onChange={(e) => {
+              setForms(prev => prev.map(f => 
+                f.id === form.id ? { ...f, flavors: e.target.value } : f
+              ));
+            }}
+            className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-sm text-zinc-900"
+          >
+            <option value="">Até 2 sabores</option>
+            <option value="1">1 sabor</option>
+            <option value="2">2 sabores</option>
+            <option value="3">3 sabores</option>
+            <option value="4">4 sabores</option>
+          </select>
+          <select
+            value={form.available}
+            onChange={(e) => {
+              setForms(prev => prev.map(f => 
+                f.id === form.id ? { ...f, available: e.target.value } : f
+              ));
+            }}
+            className="w-full px-4 py-3 rounded-lg border border-zinc-200 outline-none text-sm text-zinc-900"
+          >
+            <option value="true">Disponível</option>
+            <option value="false">Indisponível</option>
+          </select>
+          <button
+            onClick={() => handleDeleteSize(form.id)}
+            className="h-[46px] w-[46px] flex items-center justify-center rounded-lg border border-red-200 hover:bg-red-50"
+          >
+            <Trash size={20} className="text-red-500" />
+          </button>
+        </div>
+      ))}
+
+      {showFields && forms.length > 0 && (
+        <div className="flex justify-end mt-6">
+          <button 
+            onClick={handleConfirm}
+            className="bg-[#FF5900] text-white px-8 py-3 rounded-full text-sm font-medium hover:bg-[#FF5900]/90"
+          >
+            Confirmar
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/cardapio/cadastro-pizza/constants.ts
+++ b/src/app/cardapio/cadastro-pizza/constants.ts
@@ -1,0 +1,25 @@
+export const PIZZA_SIZES = [
+  {
+    id: 'small',
+    label: 'Pizza pequena',
+  },
+  {
+    id: 'large',
+    label: 'Pizza grande',
+  }
+] as const;
+
+export const AVAILABILITY_OPTIONS = [
+  {
+    value: 'available',
+    label: 'Disponível'
+  },
+  {
+    value: 'unavailable',
+    label: 'Indisponível'
+  }
+] as const;
+
+export const ALLOWED_FILE_TYPES = ['jpg', 'jpeg', 'png', 'heic'];
+export const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+export const MIN_IMAGE_RESOLUTION = 500; // 500x500

--- a/src/app/cardapio/cadastro-pizza/page.tsx
+++ b/src/app/cardapio/cadastro-pizza/page.tsx
@@ -1,14 +1,26 @@
 "use client"
 
+import { useState } from 'react';
 import { CaretLeft } from "@phosphor-icons/react";
 import Link from "next/link";
 import { PizzaRegistrationCard } from "./components/PizzaRegistrationCard";
 import { PizzaCategorySection } from "./components/sections/PizzaCategorySection";
+import { SizeSection } from "./components/sections/SizeSection";
+import { EdgeSection } from "./components/sections/EdgeSection";
+import { FlavorSection } from "./components/sections/FlavorSection";
 
 export default function CadastroPizzaPage() {
+  const [currentStep, setCurrentStep] = useState(1);
+  const [isConfirmed, setIsConfirmed] = useState(false);
+
   const handleAddCategory = () => {
     // Lógica para adicionar categoria
     console.log('Adicionar categoria');
+  };
+
+  const handleConfirm = () => {
+    setIsConfirmed(true);
+    setCurrentStep(prev => prev + 1);
   };
 
   return (
@@ -24,10 +36,14 @@ export default function CadastroPizzaPage() {
       <div className="max-w-[100%] space-y-4">
         <PizzaRegistrationCard />
         <PizzaCategorySection onAddCategory={handleAddCategory} />
+        {currentStep >= 2 && <SizeSection />}
+        {currentStep >= 3 && <EdgeSection />}
+        {currentStep >= 4 && <FlavorSection />}
 
         {/* Botão Continuar */}
         <div className="flex justify-end pt-4">
           <button 
+            onClick={handleConfirm}
             className="bg-[#FF5900] text-white px-8 py-3 rounded-full text-sm font-medium hover:bg-[#FF5900]/90"
           >
             Continuar

--- a/src/app/cardapio/cadastro-pizza/types.ts
+++ b/src/app/cardapio/cadastro-pizza/types.ts
@@ -1,0 +1,44 @@
+export interface FlavorSize {
+  size: string;
+  price: string;
+  promotionalPrice: string;
+  available: boolean;
+}
+
+export interface Flavor {
+  id: string;
+  name: string;
+  description: string;
+  image: string;
+  sizes: FlavorSize[];
+}
+
+export interface FlavorModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onAdd: (flavor: Flavor) => void;
+}
+
+export interface Category {
+  id: number;
+  name: string;
+  parentId?: number;
+}
+
+export interface CategoryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (selectedCategories: string[]) => void;
+}
+
+export interface Edge {
+  flavor: string;
+  price: string;
+  available: boolean;
+}
+
+export interface EdgeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onAdd: (edge: Edge) => void;
+}

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,10 +1,5 @@
 import { useState } from 'react';
-
-interface Category {
-  id: number;
-  name: string;
-  parentId?: number;
-}
+import { Category } from '@/app/cardapio/cadastro-pizza/types';
 
 export function useCategories() {
   const [categories] = useState<Category[]>([

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+interface Category {
+  id: number;
+  name: string;
+  parentId?: number;
+}
+
+export function useCategories() {
+  const [categories] = useState<Category[]>([
+    { id: 1, name: 'Lanches' },
+    { id: 2, name: 'Bebidas' },
+    { id: 3, name: 'Refrigerantes', parentId: 2 },
+    { id: 4, name: 'Cervejas', parentId: 2 },
+    { id: 5, name: 'Combos' },
+    { id: 6, name: 'Promoções' },
+  ]);
+
+  const searchCategories = (term: string) => {
+    if (!term) return categories;
+    return categories.filter(category => 
+      category.name.toLowerCase().includes(term.toLowerCase())
+    );
+  };
+
+  return {
+    categories,
+    searchCategories
+  };
+}


### PR DESCRIPTION
# Adiciona FlavorSection com modal de cadastro

## O que foi feito
- Implementa nova seção de sabores no cardápio
- Adiciona modal para cadastro de sabores
- Implementa grid de listagem de sabores
- Adiciona funcionalidade de preços por tamanho
- Implementa controle de disponibilidade dos sabores

## Como testar
1. Acesse a página de cardápio
2. Clique em "Adicionar sabor"
3. Preencha as informações do sabor no modal:
   - Nome e descrição
   - Upload de imagem
   - Preços para cada tamanho
   - Disponibilidade
4. Verifique se o sabor aparece na listagem
5. Teste a edição e remoção do sabor
6. Verifique o status de disponibilidade

## Tipo de alteração
- [x] Nova feature
- [ ] Bugfix
- [ ] Breaking change
- [x] Melhoria de UI/UX


## Observações adicionais
- O modal segue o novo padrão de design do sistema
- Implementado grid responsivo para listagem
- Adicionado controle de estados para todos os campos
- Validação de campos obrigatórios